### PR TITLE
Allow to pass in the microphone audio stream and sample rate

### DIFF
--- a/lib/bumblebee-node.js
+++ b/lib/bumblebee-node.js
@@ -194,7 +194,7 @@ class BumblebeeNode extends Jaxcore.Service {
 			// records as int16, convert back to float for porcupine
 			let float32arr = pcmConvert(data, 'int16 mono le', 'float32');
 			this.processAudio(float32arr, sampleRate);
-			this.emit('data', data, 16000);
+			this.emit('data', data, sampleRate);
 		});
 		
 		this.emit('start');

--- a/lib/bumblebee-node.js
+++ b/lib/bumblebee-node.js
@@ -134,23 +134,23 @@ class BumblebeeNode extends Jaxcore.Service {
 		this.disconnect();
 	}
 	
-	start() {
+	start(stream, sampleRate) {
 		if (this.state.recording) {
 			this.log('already started');
 			return;
 		}
 		if (this.state.connected) {
-			this._start();
+			this._start(stream, sampleRate);
 		}
 		else {
 			this.once('connect',() => {
-				this._start();
+				this._start(stream, sampleRate);
 			});
 			this.connect();
 		}
 	}
 	
-	_start() {
+	_start(stream, sampleRate) {
 		if (this.state.recording) return;
 		this.setState({recording: true});
 		
@@ -167,15 +167,19 @@ class BumblebeeNode extends Jaxcore.Service {
 		let keywordIDArray = Object.values(keywordIDs);
 		
 		this.porcupine = Porcupine.create(keywordIDArray, sensitivities);
-		
-		this.recorder = new AudioRecorder({
-			program: process.platform === 'win32' ? 'sox' : 'rec',
-			silence: 0
-		});
-		
-		this.recorder.start();
-		
-		let stream = this.recorder.stream();
+
+		if (!stream) {
+			this.recorder = new AudioRecorder({
+				program: process.platform === 'win32' ? 'sox' : 'rec',
+				silence: 0
+			});
+			this.recorder.start();
+			stream = this.recorder.stream();
+		}
+		if (!sampleRate) {
+			sampleRate = 16000;
+		}
+
 		stream.on(`error`, () => {
 			console.log('Recording error.');
 		});
@@ -189,16 +193,15 @@ class BumblebeeNode extends Jaxcore.Service {
 			
 			// records as int16, convert back to float for porcupine
 			let float32arr = pcmConvert(data, 'int16 mono le', 'float32');
-			this.processAudio(float32arr);
+			this.processAudio(float32arr, sampleRate);
 			this.emit('data', data, 16000);
 		});
 		
 		this.emit('start');
 	}
 	
-	processAudio(inputFrame) {
-		let inputSampleRate = 16000;
-		
+	processAudio(inputFrame, inputSampleRate) {
+
 		for (let i = 0; i < inputFrame.length; i++) {
 			this.inputBuffer.push((inputFrame[i]) * 32767);
 		}


### PR DESCRIPTION
BumbleBee uses `node-audiorecorder` to record the audio from the microphone, do the wake word detection, and pass the audio data on to the caller.

However, `node-audiorecorder` is very simplistic. It appears to always use the default device, which in my case is not the right microphone for speech recognition. (My project has configuration to allow the user to select the audio devices.) Aside from that, `node-audiorecorder` implicitly depends on `sox` with `rec` command line program being installed on the platform, in the path etc..

Also, it's currently hard-coded to 16000 Hz sample rate. There already is a variable in the code (`... * PV_SAMPLE_RATE / inputSampleRate`), so it seems it's prepared for being passed in by the caller, but it's not a parameter yet. Probably due to lack of need so far.

This code change allows the caller to pass in an audio input stream, and the sample rate.